### PR TITLE
Implement editor menu functionalities

### DIFF
--- a/src/components/ObsidianLayout.tsx
+++ b/src/components/ObsidianLayout.tsx
@@ -2,7 +2,6 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { TabBar, type TabType } from './Tab';
 import Editor from './Editor';
-import LinkedViews from './LinkedViews';
 import WorkspaceManager from './WorkspaceManager';
 import { useDocuments } from '@/store/documents';
 import { useTabManager } from '@/store/tabManager';
@@ -453,12 +452,6 @@ const ObsidianLayout: React.FC = () => {
               <div className="flex-1">
                 <Editor documentId={node.tabs.find(t => t.isActive)?.documentId} />
               </div>
-              <LinkedViews
-                activeTab={node.tabs.find(t => t.isActive)}
-                panelId={node.id}
-                position="right"
-                className="w-64"
-              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Remove the per-editor `LinkedViews` sidebar to simplify the editor interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-69f1a151-9dd0-445a-b84a-3ea48aa365ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69f1a151-9dd0-445a-b84a-3ea48aa365ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

