### PR TITLE
Fix and improve tab dropdown menu

### DIFF
--- a/src/components/StackedTab.tsx
+++ b/src/components/StackedTab.tsx
@@ -153,6 +153,7 @@ const StackedTab: React.FC<StackedTabProps> = ({
           <DropdownMenuContent align="start" className="w-48 bg-card border border-border shadow-dropdown z-50">
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
+              onSelect={handleUnstack}
               onClick={handleUnstack}
             >
               取消堆叠
@@ -160,12 +161,14 @@ const StackedTab: React.FC<StackedTabProps> = ({
             <DropdownMenuSeparator />
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
+              onSelect={() => activeTab && handleCloseOthers(activeTab.id)}
               onClick={() => activeTab && handleCloseOthers(activeTab.id)}
             >
               关闭其他标签页
             </DropdownMenuItem>
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
+              onSelect={handleCloseAll}
               onClick={handleCloseAll}
             >
               关闭所有标签页

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -188,6 +188,7 @@ const Tab: React.FC<TabProps> = ({
         >
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('close')}
             onClick={() => handleDropdownClick('close')}
             disabled={tab.isLocked}
           >
@@ -195,12 +196,14 @@ const Tab: React.FC<TabProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('closeOthers')}
             onClick={() => handleDropdownClick('closeOthers')}
           >
             关闭其他标签页
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('closeAll')}
             onClick={() => handleDropdownClick('closeAll')}
           >
             全部关闭
@@ -208,12 +211,14 @@ const Tab: React.FC<TabProps> = ({
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('duplicate')}
             onClick={() => handleDropdownClick('duplicate')}
           >
             复制标签页
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('rename')}
             onClick={() => handleDropdownClick('rename')}
           >
             重命名
@@ -221,12 +226,14 @@ const Tab: React.FC<TabProps> = ({
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('toggleLock')}
             onClick={() => handleDropdownClick('toggleLock')}
           >
             {tab.isLocked ? '解锁' : '锁定'}
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('copyPath')}
             onClick={() => handleDropdownClick('copyPath')}
             disabled={!tab.filePath}
           >
@@ -234,6 +241,7 @@ const Tab: React.FC<TabProps> = ({
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('revealInExplorer')}
             onClick={() => handleDropdownClick('revealInExplorer')}
           >
             在资源管理器中显示
@@ -241,12 +249,14 @@ const Tab: React.FC<TabProps> = ({
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('splitHorizontal')}
             onClick={() => handleDropdownClick('splitHorizontal')}
           >
             左右分屏
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
+            onSelect={() => handleDropdownClick('splitVertical')}
             onClick={() => handleDropdownClick('splitVertical')}
           >
             上下分屏


### PR DESCRIPTION
Add `onSelect` handlers to tab and stacked-tab dropdown menu items to fix non-functional menu actions.

Radix DropdownMenu expects `onSelect` for reliable activation, but the menu items were only using `onClick`, causing the actions to be no-ops.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cc9de35-25f2-4770-bbc7-be345fbb0a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cc9de35-25f2-4770-bbc7-be345fbb0a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

