### PR TITLE
Fix and improve tab dropdown menu

### DIFF
--- a/src/components/StackedTab.tsx
+++ b/src/components/StackedTab.tsx
@@ -153,20 +153,20 @@ const StackedTab: React.FC<StackedTabProps> = ({
           <DropdownMenuContent align="start" className="w-48 bg-card border border-border shadow-dropdown z-50">
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
-              onClick={handleUnstack}
+              onSelect={handleUnstack}
             >
               取消堆叠
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
-              onClick={() => activeTab && handleCloseOthers(activeTab.id)}
+              onSelect={() => activeTab && handleCloseOthers(activeTab.id)}
             >
               关闭其他标签页
             </DropdownMenuItem>
             <DropdownMenuItem 
               className="text-sm hover:bg-secondary cursor-pointer"
-              onClick={handleCloseAll}
+              onSelect={handleCloseAll}
             >
               关闭所有标签页
             </DropdownMenuItem>

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -188,66 +188,66 @@ const Tab: React.FC<TabProps> = ({
         >
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('close')}
+            onSelect={() => handleDropdownClick('close')}
             disabled={tab.isLocked}
           >
             关闭
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('closeOthers')}
+            onSelect={() => handleDropdownClick('closeOthers')}
           >
             关闭其他标签页
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('closeAll')}
+            onSelect={() => handleDropdownClick('closeAll')}
           >
             全部关闭
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('duplicate')}
+            onSelect={() => handleDropdownClick('duplicate')}
           >
             复制标签页
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('rename')}
+            onSelect={() => handleDropdownClick('rename')}
           >
             重命名
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('toggleLock')}
+            onSelect={() => handleDropdownClick('toggleLock')}
           >
             {tab.isLocked ? '解锁' : '锁定'}
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('copyPath')}
+            onSelect={() => handleDropdownClick('copyPath')}
             disabled={!tab.filePath}
           >
             复制文件路径
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('revealInExplorer')}
+            onSelect={() => handleDropdownClick('revealInExplorer')}
           >
             在资源管理器中显示
           </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('splitHorizontal')}
+            onSelect={() => handleDropdownClick('splitHorizontal')}
           >
             左右分屏
           </DropdownMenuItem>
           <DropdownMenuItem 
             className="text-sm hover:bg-secondary cursor-pointer"
-            onClick={() => handleDropdownClick('splitVertical')}
+            onSelect={() => handleDropdownClick('splitVertical')}
           >
             上下分屏
           </DropdownMenuItem>

--- a/src/components/TabGroup.tsx
+++ b/src/components/TabGroup.tsx
@@ -210,13 +210,13 @@ const TabGroup: React.FC<TabGroupProps> = ({
             <DropdownMenuContent align="end" className="w-48 bg-card border border-border shadow-dropdown">
               <DropdownMenuItem 
                 className="text-sm hover:bg-secondary cursor-pointer"
-                onClick={() => setIsRenaming(true)}
+                onSelect={() => setIsRenaming(true)}
               >
                 重命名组
               </DropdownMenuItem>
               <DropdownMenuItem 
                 className="text-sm hover:bg-secondary cursor-pointer"
-                onClick={() => setShowColorPicker(!showColorPicker)}
+                onSelect={() => setShowColorPicker(!showColorPicker)}
               >
                 <Palette className="w-4 h-4 mr-2" />
                 更改颜色
@@ -224,7 +224,7 @@ const TabGroup: React.FC<TabGroupProps> = ({
               <DropdownMenuSeparator />
               <DropdownMenuItem 
                 className="text-sm hover:bg-secondary cursor-pointer"
-                onClick={handleToggleLock}
+                onSelect={handleToggleLock}
               >
                 {group.isLocked ? (
                   <>
@@ -241,13 +241,13 @@ const TabGroup: React.FC<TabGroupProps> = ({
               <DropdownMenuSeparator />
               <DropdownMenuItem 
                 className="text-sm hover:bg-secondary cursor-pointer"
-                onClick={handleCloseAllTabs}
+                onSelect={handleCloseAllTabs}
               >
                 关闭所有标签页
               </DropdownMenuItem>
               <DropdownMenuItem 
                 className="text-sm hover:bg-secondary cursor-pointer text-destructive"
-                onClick={handleDeleteGroup}
+                onSelect={handleDeleteGroup}
               >
                 删除组
               </DropdownMenuItem>

--- a/src/components/WorkspaceManager.tsx
+++ b/src/components/WorkspaceManager.tsx
@@ -295,12 +295,12 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                             </button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
-                            <DropdownMenuItem onClick={() => handleLoadLayout(layout.id)}>
+                            <DropdownMenuItem onSelect={() => handleLoadLayout(layout.id)}>
                               <FolderOpen className="w-4 h-4 mr-2" />
                               加载布局
                             </DropdownMenuItem>
                             <DropdownMenuItem 
-                              onClick={() => handleSetDefault(layout.id)}
+                              onSelect={() => handleSetDefault(layout.id)}
                               disabled={layout.isDefault}
                             >
                               {layout.isDefault ? (
@@ -309,12 +309,12 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                                 <><Star className="w-4 h-4 mr-2" />设为默认</>
                               )}
                             </DropdownMenuItem>
-                            <DropdownMenuItem onClick={() => handleExportLayout(layout)}>
+                            <DropdownMenuItem onSelect={() => handleExportLayout(layout)}>
                               <Download className="w-4 h-4 mr-2" />
                               导出布局
                             </DropdownMenuItem>
                             <DropdownMenuItem 
-                              onClick={() => {
+                              onSelect={() => {
                                 navigator.clipboard.writeText(JSON.stringify(layout, null, 2));
                               }}
                             >
@@ -323,7 +323,7 @@ const WorkspaceManager: React.FC<WorkspaceManagerProps> = ({
                             </DropdownMenuItem>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem 
-                              onClick={() => handleDeleteLayout(layout.id)}
+                              onSelect={() => handleDeleteLayout(layout.id)}
                               className="text-destructive focus:text-destructive"
                             >
                               <Trash2 className="w-4 h-4 mr-2" />


### PR DESCRIPTION
Switch `DropdownMenuItem` event handlers from `onClick` to `onSelect` in tab-related components.

The tab dropdown menu actions were unresponsive because Radix UI's `DropdownMenuItem` component uses `onSelect` as its primary activation event, not `onClick`. This change ensures all dropdown menu items trigger their associated actions correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-add48d05-b2b7-40c7-8def-dd02e5613024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-add48d05-b2b7-40c7-8def-dd02e5613024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

